### PR TITLE
remove vehicle_Nameprobe_comms_1_a

### DIFF
--- a/src/vehicles.ini
+++ b/src/vehicles.ini
@@ -233,7 +233,6 @@ vehicle_NameORIG_m50=Origin M50 Interceptor
 vehicle_NameORIG_X1_Force=Origin X1 Force
 vehicle_NameORIG_X1_Velocity=Origin X1 Velocity
 vehicle_NameORIG_X1=Origin X1
-vehicle_Nameprobe_comms_1_a=CHCO Auris PDC Monitor
 vehicle_NameRSI_Apollo_Medivac=RSI Apollo Medivac
 vehicle_NameRSI_Apollo_Triage=RSI Apollo Triage
 vehicle_NameRSI_Arrastra=RSI Arrastra


### PR DESCRIPTION
Probably an accidental inclusion due to having the same prefix that ships have.
